### PR TITLE
Update HPCToolkit modules for Frontier

### DIFF
--- a/gpu/amd/lammps.rocm/setup-env/frontier.sh
+++ b/gpu/amd/lammps.rocm/setup-env/frontier.sh
@@ -24,10 +24,10 @@ else
   module purge
 
   # load modules needed to build and run lammps
-  module load Core PrgEnv-amd amd/5.7.1 rocm/5.7.1 cray-mpich cmake craype-x86-trento craype-accel-amd-gfx90a
+  module load Core/24.07 PrgEnv-amd amd/5.7.1 rocm/5.7.1 cray-mpich cmake craype-x86-trento craype-accel-amd-gfx90a
 
   # modules for hpctoolkit
-  export HPCTOOLKIT_MODULES_HPCTOOLKIT="module load ums ums023 hpctoolkit"
+  export HPCTOOLKIT_MODULES_HPCTOOLKIT="module load Core/24.07 hpctoolkit"
   $HPCTOOLKIT_MODULES_HPCTOOLKIT
 
   # environment settings for this example

--- a/gpu/amd/quicksilver.rocm/setup-env/frontier.sh
+++ b/gpu/amd/quicksilver.rocm/setup-env/frontier.sh
@@ -24,10 +24,10 @@ else
   module purge
 
   # load modules needed to build and run quicksilver
-  module load Core PrgEnv-amd amd/5.7.1 rocm/5.7.1 cray-mpich cmake craype-x86-trento craype-accel-amd-gfx90a
+  module load Core/24.07 PrgEnv-amd amd/5.7.1 rocm/5.7.1 cray-mpich cmake craype-x86-trento craype-accel-amd-gfx90a
 
   # modules for hpctoolkit
-  export HPCTOOLKIT_MODULES_HPCTOOLKIT="module load ums ums023 hpctoolkit"
+  export HPCTOOLKIT_MODULES_HPCTOOLKIT="module load Core/24.07 hpctoolkit"
   $HPCTOOLKIT_MODULES_HPCTOOLKIT
 
   # environment settings for this example


### PR DESCRIPTION
There is an official (i.e. not UMS) HPCToolkit deployment available on Frontier, to use it just load a newer version of the `Core` module, e.g.

```console
$ module load Core/24.07
```

This HPCToolkit seems to work with the tutorial examples, so we should encourage using it over our un-updatable UMS installation.